### PR TITLE
(feat) Add tooltips support with a examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ index.html
 
 *~
 .*~
+
+.idea

--- a/templates/base.html
+++ b/templates/base.html
@@ -185,9 +185,14 @@
     <footer class="footer">
         <div class="container">
             <div class="row">
-                <div>Site created by Marielle Kaidafaux (Adamantoise)</div>                
+                <div>Site created by Marielle Kaidafaux (Adamantoise)</div>
             </div>
         </div>
     </footer>
+    <script type="application/javascript">
+        $(function () {
+          $('[data-toggle="tooltip"]').tooltip()
+        })
+    </script>
 </body>
-
+</html>

--- a/templates/calc.html
+++ b/templates/calc.html
@@ -63,13 +63,17 @@
                         <table class="table table-striped">
                             <thead>
                                 <div>
-                                <tr>
-                                    <th scope="col">Player</th>
-                                    <th scope="col">Job</th>
-                                    <th scope="col">Adjusted Damage</th>
-                                    <th scope="col">Raw Damage</th>
-                                    <th scope="col">Has Card?</th>
-                                </tr>
+                                    <tr>
+                                        <th scope="col">
+                                            <span data-toggle="tooltip" data-placement="bottom" title="Tooltip that will be displayed below the player">Player</span>
+                                        </th>
+                                        <th scope="col">
+                                            <span data-toggle="tooltip" data-placement="bottom" title="An other tooltip">Job</span>
+                                        </th>
+                                        <th scope="col">Adjusted Damage</th>
+                                        <th scope="col">Raw Damage</th>
+                                        <th scope="col">Has Card?</th>
+                                    </tr>
                                 </div>
                             </thead>
                             <tbody>


### PR DESCRIPTION
Adds support for the tooltips to work.

For it to properly align to the text a additional `span` tag is needed because otherwise it will align to the `th` tag instead and will be ofset from the text.

With the `span` tag
![image](https://user-images.githubusercontent.com/3686258/110015217-4aafcb80-7d2c-11eb-8a80-e6d40fb0afc9.png)

Without the `span` tag
![image](https://user-images.githubusercontent.com/3686258/110015259-54d1ca00-7d2c-11eb-8da4-8cf33e45aa57.png)

Additional minor changes included in this PR:
* add missing html closing tag
* add PyCharm config folder to the .gitignore